### PR TITLE
Forget the name of the global functions on restore

### DIFF
--- a/src/Spies/GlobalSpies.php
+++ b/src/Spies/GlobalSpies.php
@@ -96,6 +96,9 @@ class GlobalSpies {
 		foreach ( array_values( self::$redefined_functions ) as $handle ) {
 			\Patchwork\restore( $handle );
 		}
+		
+		// forget the name of the global functions we already defined.
+		self::$global_functions = [];
 	}
 
 	public static function call_original_global_function( $function_name, $args ) {


### PR DESCRIPTION
Fixes https://github.com/sirbrillig/spies/issues/27

When a new global function is defined, we skip if the function has been defined already (by looking at `self::$global_functions`).
But we don't clear the memory when the original definition is restored, so after restoration, re-defining doesn't work because the name is found `self::$global_functions`.